### PR TITLE
DAPH-177 consume latest docker base image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opguk/base:0.1.213
+FROM registry.service.opg.digital/opguk/base
 
 RUN groupadd supervisor
 


### PR DESCRIPTION
deployed sucessfully to:  https://front2-devops01.dev.lpa.opg.digital/home
using: https://jenkins.service.opg.digital/job/LPA/job/lpa_stack_update_deploy/704/
